### PR TITLE
feat: Add keyboard-based device switching during recording

### DIFF
--- a/src/omr/backends/wasapi.py
+++ b/src/omr/backends/wasapi.py
@@ -437,6 +437,9 @@ class WasapiBackend:
         mic_thread: threading.Thread | None = None
         loopback_thread: threading.Thread | None = None
 
+        # Logger for this method
+        logger = logging.getLogger(__name__)
+
         # Shared state for device switching
         reader_pause_event = threading.Event()
         reader_resume_event = threading.Event()

--- a/src/omr/cli/commands/record.py
+++ b/src/omr/cli/commands/record.py
@@ -116,10 +116,10 @@ def _create_status_panel(
         status_lines.append("[dim]─────────── Keyboard Shortcuts ───────────[/dim]")
         shortcuts = []
         if session.mode in (RecordingMode.MIC, RecordingMode.BOTH):
-            shortcuts.append("[m] Switch Mic")
+            shortcuts.append("\\[m] Switch Mic")
         if session.mode in (RecordingMode.LOOPBACK, RecordingMode.BOTH):
-            shortcuts.append("[l] Switch Loopback")
-        shortcuts.append("[q] Stop")
+            shortcuts.append("\\[l] Switch Loopback")
+        shortcuts.append("\\[q] Stop")
         status_lines.append("[dim]" + "  ".join(shortcuts) + "[/dim]")
 
     text = Text.from_markup("\n".join(status_lines))

--- a/src/omr/core/input_handler.py
+++ b/src/omr/core/input_handler.py
@@ -1,0 +1,275 @@
+"""Keyboard input handler for recording control.
+
+Provides non-blocking keyboard input handling for device switching
+and recording control during active recording sessions.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from dataclasses import dataclass
+from enum import Enum, auto
+from queue import Empty, Queue
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+
+class InputCommand(Enum):
+    """Commands triggered by keyboard input."""
+
+    STOP = auto()  # Stop recording (q key)
+    SWITCH_MIC = auto()  # Enter mic selection mode (m key)
+    SWITCH_LOOPBACK = auto()  # Enter loopback selection mode (l key)
+    SELECT_DEVICE = auto()  # Select device by number (0-9)
+    CANCEL = auto()  # Cancel selection mode (Esc)
+    REFRESH_DEVICES = auto()  # Refresh device list (r key)
+
+
+class SelectionMode(Enum):
+    """Current device selection mode."""
+
+    NONE = auto()  # Normal recording mode
+    MIC = auto()  # Selecting microphone
+    LOOPBACK = auto()  # Selecting loopback device
+
+
+@dataclass
+class InputEvent:
+    """Represents a keyboard input event."""
+
+    command: InputCommand
+    value: int | None = None  # Device number for SELECT_DEVICE
+
+    def __repr__(self) -> str:
+        if self.value is not None:
+            return f"InputEvent({self.command.name}, value={self.value})"
+        return f"InputEvent({self.command.name})"
+
+
+class KeyInputHandler:
+    """Handles keyboard input in a separate thread.
+
+    Uses msvcrt on Windows for non-blocking keyboard input.
+    On non-Windows platforms, provides a stub implementation.
+    """
+
+    def __init__(self) -> None:
+        self._queue: Queue[InputEvent] = Queue()
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._selection_mode = SelectionMode.NONE
+        self._lock = threading.Lock()
+        self._is_windows = sys.platform == "win32"
+
+    @property
+    def selection_mode(self) -> SelectionMode:
+        """Get the current selection mode."""
+        with self._lock:
+            return self._selection_mode
+
+    def enter_selection_mode(self, mode: SelectionMode) -> None:
+        """Enter device selection mode.
+
+        Args:
+            mode: The selection mode to enter (MIC or LOOPBACK)
+        """
+        with self._lock:
+            self._selection_mode = mode
+
+    def exit_selection_mode(self) -> None:
+        """Exit device selection mode."""
+        with self._lock:
+            self._selection_mode = SelectionMode.NONE
+
+    def start(self) -> None:
+        """Start the keyboard input handler thread."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._input_loop,
+            daemon=True,
+            name="key_input_handler",
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the keyboard input handler thread."""
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+            self._thread = None
+
+    def get_event(self, timeout: float = 0.1) -> InputEvent | None:
+        """Get the next input event from the queue.
+
+        Args:
+            timeout: Maximum time to wait for an event in seconds.
+
+        Returns:
+            The next InputEvent, or None if no event is available.
+        """
+        try:
+            return self._queue.get(timeout=timeout)
+        except Empty:
+            return None
+
+    def _input_loop(self) -> None:
+        """Main input loop running in a separate thread."""
+        if self._is_windows:
+            self._windows_input_loop()
+        else:
+            self._unix_input_loop()
+
+    def _windows_input_loop(self) -> None:
+        """Windows-specific input loop using msvcrt."""
+        import msvcrt
+
+        while not self._stop_event.is_set():
+            # Check if a key is available
+            if msvcrt.kbhit():
+                try:
+                    # Get the key (bytes)
+                    key = msvcrt.getch()
+                    self._process_key(key)
+                except Exception:
+                    # Ignore any input errors
+                    pass
+            else:
+                # Small sleep to prevent busy waiting
+                self._stop_event.wait(0.05)
+
+    def _unix_input_loop(self) -> None:
+        """Unix-specific input loop (stub for cross-platform compatibility).
+
+        Note: This is a basic implementation. For full Unix support,
+        consider using termios/tty or a library like pynput.
+        """
+        import select
+
+        while not self._stop_event.is_set():
+            try:
+                # Check if stdin has data available
+                if select.select([sys.stdin], [], [], 0.1)[0]:
+                    key = sys.stdin.read(1)
+                    if key:
+                        self._process_key(key.encode())
+            except Exception:
+                # If select fails (not a terminal), just wait
+                self._stop_event.wait(0.1)
+
+    def _process_key(self, key: bytes) -> None:
+        """Process a key press and generate appropriate event.
+
+        Args:
+            key: The key that was pressed (as bytes).
+        """
+        event: InputEvent | None = None
+
+        with self._lock:
+            mode = self._selection_mode
+
+        # Handle key based on current mode
+        if mode == SelectionMode.NONE:
+            # Normal mode: handle control keys
+            event = self._handle_normal_mode(key)
+        else:
+            # Selection mode: handle device selection
+            event = self._handle_selection_mode(key)
+
+        if event is not None:
+            self._queue.put(event)
+
+    def _handle_normal_mode(self, key: bytes) -> InputEvent | None:
+        """Handle key press in normal (non-selection) mode.
+
+        Args:
+            key: The key that was pressed.
+
+        Returns:
+            An InputEvent if the key is recognized, None otherwise.
+        """
+        try:
+            char = key.decode("utf-8").lower()
+        except UnicodeDecodeError:
+            return None
+
+        if char == "q":
+            return InputEvent(InputCommand.STOP)
+        elif char == "m":
+            return InputEvent(InputCommand.SWITCH_MIC)
+        elif char == "l":
+            return InputEvent(InputCommand.SWITCH_LOOPBACK)
+        elif char == "r":
+            return InputEvent(InputCommand.REFRESH_DEVICES)
+
+        return None
+
+    def _handle_selection_mode(self, key: bytes) -> InputEvent | None:
+        """Handle key press in device selection mode.
+
+        Args:
+            key: The key that was pressed.
+
+        Returns:
+            An InputEvent if the key is recognized, None otherwise.
+        """
+        # Check for Escape key (0x1b)
+        if key == b"\x1b":
+            return InputEvent(InputCommand.CANCEL)
+
+        try:
+            char = key.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+
+        # Check for number keys (0-9)
+        if char.isdigit():
+            device_num = int(char)
+            return InputEvent(InputCommand.SELECT_DEVICE, value=device_num)
+
+        # Also allow q to stop in selection mode
+        if char.lower() == "q":
+            return InputEvent(InputCommand.STOP)
+
+        # Allow Escape via 'e' key as fallback
+        if char.lower() == "e":
+            return InputEvent(InputCommand.CANCEL)
+
+        return None
+
+    def __enter__(self) -> KeyInputHandler:
+        """Context manager entry."""
+        self.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: object,
+        exc_val: object,
+        exc_tb: object,
+    ) -> None:
+        """Context manager exit."""
+        self.stop()
+
+
+def is_input_available() -> bool:
+    """Check if keyboard input handling is available on this platform.
+
+    Returns:
+        True if keyboard input can be handled, False otherwise.
+    """
+    if sys.platform == "win32":
+        try:
+            import msvcrt  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+    else:
+        # Unix platforms can use select with stdin
+        return True

--- a/tests/test_device_switching.py
+++ b/tests/test_device_switching.py
@@ -1,0 +1,309 @@
+"""Tests for device switching functionality."""
+
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omr.config.settings import RecordingMode
+from omr.core.device_manager import AudioDevice, DeviceType
+
+
+class TestRecordingSessionDeviceSwitching:
+    """Tests for device switching in RecordingSession."""
+
+    @pytest.fixture
+    def mock_session(self):
+        """Create a mock recording session with device switching support."""
+        from omr.core.audio_capture import RecordingSession
+
+        mic_device = AudioDevice(
+            index=0,
+            name="Test Microphone",
+            device_type=DeviceType.INPUT,
+            host_api="WASAPI",
+            channels=1,
+            default_sample_rate=44100.0,
+            is_default=True,
+        )
+
+        loopback_device = AudioDevice(
+            index=1,
+            name="Test Loopback",
+            device_type=DeviceType.LOOPBACK,
+            host_api="WASAPI",
+            channels=2,
+            default_sample_rate=48000.0,
+            is_default=True,
+        )
+
+        session = RecordingSession(
+            mode=RecordingMode.BOTH,
+            output_path=Path("/tmp/test.mp3"),
+            mic_device=mic_device,
+            loopback_device=loopback_device,
+        )
+        return session
+
+    def test_device_switch_event_initial_state(self, mock_session):
+        """Test device switch event is initially not set."""
+        assert not mock_session.device_switch_event.is_set()
+
+    def test_request_device_switch_mic(self, mock_session):
+        """Test requesting mic device switch."""
+        new_mic = AudioDevice(
+            index=2,
+            name="New Microphone",
+            device_type=DeviceType.INPUT,
+            host_api="WASAPI",
+            channels=1,
+            default_sample_rate=44100.0,
+            is_default=False,
+        )
+
+        mock_session.request_device_switch(mic_device=new_mic)
+
+        assert mock_session.device_switch_event.is_set()
+
+    def test_request_device_switch_loopback(self, mock_session):
+        """Test requesting loopback device switch."""
+        new_loopback = AudioDevice(
+            index=3,
+            name="New Loopback",
+            device_type=DeviceType.LOOPBACK,
+            host_api="WASAPI",
+            channels=2,
+            default_sample_rate=48000.0,
+            is_default=False,
+        )
+
+        mock_session.request_device_switch(loopback_device=new_loopback)
+
+        assert mock_session.device_switch_event.is_set()
+
+    def test_request_device_switch_both(self, mock_session):
+        """Test requesting both device switch."""
+        new_mic = AudioDevice(
+            index=2,
+            name="New Microphone",
+            device_type=DeviceType.INPUT,
+            host_api="WASAPI",
+            channels=1,
+            default_sample_rate=44100.0,
+            is_default=False,
+        )
+        new_loopback = AudioDevice(
+            index=3,
+            name="New Loopback",
+            device_type=DeviceType.LOOPBACK,
+            host_api="WASAPI",
+            channels=2,
+            default_sample_rate=48000.0,
+            is_default=False,
+        )
+
+        mock_session.request_device_switch(mic_device=new_mic, loopback_device=new_loopback)
+
+        assert mock_session.device_switch_event.is_set()
+
+    def test_get_pending_switch(self, mock_session):
+        """Test getting and clearing pending switch."""
+        new_mic = AudioDevice(
+            index=2,
+            name="New Microphone",
+            device_type=DeviceType.INPUT,
+            host_api="WASAPI",
+            channels=1,
+            default_sample_rate=44100.0,
+            is_default=False,
+        )
+
+        mock_session.request_device_switch(mic_device=new_mic)
+
+        # Get pending switch
+        mic, loopback = mock_session.get_pending_switch()
+
+        assert mic is not None
+        assert mic.name == "New Microphone"
+        assert loopback is None
+
+        # Event should be cleared
+        assert not mock_session.device_switch_event.is_set()
+
+        # Second call should return None, None
+        mic2, loopback2 = mock_session.get_pending_switch()
+        assert mic2 is None
+        assert loopback2 is None
+
+    def test_update_devices(self, mock_session):
+        """Test updating session devices after switch."""
+        original_mic = mock_session.mic_device
+        new_mic = AudioDevice(
+            index=2,
+            name="New Microphone",
+            device_type=DeviceType.INPUT,
+            host_api="WASAPI",
+            channels=1,
+            default_sample_rate=44100.0,
+            is_default=False,
+        )
+
+        mock_session.update_devices(mic_device=new_mic)
+
+        assert mock_session.mic_device is new_mic
+        assert mock_session.mic_device is not original_mic
+
+    def test_update_devices_none_keeps_current(self, mock_session):
+        """Test updating with None keeps current device."""
+        original_mic = mock_session.mic_device
+        original_loopback = mock_session.loopback_device
+
+        mock_session.update_devices(mic_device=None, loopback_device=None)
+
+        assert mock_session.mic_device is original_mic
+        assert mock_session.loopback_device is original_loopback
+
+    def test_thread_safety(self, mock_session):
+        """Test device switching is thread-safe."""
+        new_devices = []
+        for i in range(10):
+            new_devices.append(
+                AudioDevice(
+                    index=i + 10,
+                    name=f"Device {i}",
+                    device_type=DeviceType.INPUT,
+                    host_api="WASAPI",
+                    channels=1,
+                    default_sample_rate=44100.0,
+                    is_default=False,
+                )
+            )
+
+        errors = []
+
+        def request_switch(device):
+            try:
+                mock_session.request_device_switch(mic_device=device)
+                mock_session.get_pending_switch()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=request_switch, args=(d,))
+            for d in new_devices
+        ]
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+
+
+class TestDeviceSwitchingIntegration:
+    """Integration tests for device switching."""
+
+    @pytest.fixture
+    def mock_audio_devices(self):
+        """Create mock audio devices."""
+        mic1 = AudioDevice(
+            index=0,
+            name="Mic 1",
+            device_type=DeviceType.INPUT,
+            host_api="WASAPI",
+            channels=1,
+            default_sample_rate=44100.0,
+            is_default=True,
+        )
+        mic2 = AudioDevice(
+            index=1,
+            name="Mic 2",
+            device_type=DeviceType.INPUT,
+            host_api="WASAPI",
+            channels=1,
+            default_sample_rate=48000.0,
+            is_default=False,
+        )
+        loopback1 = AudioDevice(
+            index=2,
+            name="Loopback 1",
+            device_type=DeviceType.LOOPBACK,
+            host_api="WASAPI",
+            channels=2,
+            default_sample_rate=48000.0,
+            is_default=True,
+        )
+        loopback2 = AudioDevice(
+            index=3,
+            name="Loopback 2",
+            device_type=DeviceType.LOOPBACK,
+            host_api="WASAPI",
+            channels=2,
+            default_sample_rate=44100.0,
+            is_default=False,
+        )
+        return {
+            "mic1": mic1,
+            "mic2": mic2,
+            "loopback1": loopback1,
+            "loopback2": loopback2,
+        }
+
+    def test_device_switch_callback_pattern(self, mock_audio_devices):
+        """Test the callback pattern used for device switching."""
+        from omr.core.audio_capture import RecordingSession
+
+        session = RecordingSession(
+            mode=RecordingMode.BOTH,
+            output_path=Path("/tmp/test.mp3"),
+            mic_device=mock_audio_devices["mic1"],
+            loopback_device=mock_audio_devices["loopback1"],
+        )
+
+        # Simulate what the CLI does
+        session.request_device_switch(mic_device=mock_audio_devices["mic2"])
+
+        # Simulate what the backend callback does
+        def on_device_switch():
+            mic, loopback = session.get_pending_switch()
+            if mic:
+                session.update_devices(mic_device=mic)
+            if loopback:
+                session.update_devices(loopback_device=loopback)
+            return mic, loopback
+
+        # Check event is set
+        assert session.device_switch_event.is_set()
+
+        # Call the callback
+        new_mic, new_loopback = on_device_switch()
+
+        # Verify results
+        assert new_mic is mock_audio_devices["mic2"]
+        assert new_loopback is None
+        assert session.mic_device is mock_audio_devices["mic2"]
+        assert not session.device_switch_event.is_set()
+
+    def test_multiple_rapid_switches(self, mock_audio_devices):
+        """Test handling multiple rapid switch requests."""
+        from omr.core.audio_capture import RecordingSession
+
+        session = RecordingSession(
+            mode=RecordingMode.BOTH,
+            output_path=Path("/tmp/test.mp3"),
+            mic_device=mock_audio_devices["mic1"],
+            loopback_device=mock_audio_devices["loopback1"],
+        )
+
+        # Request multiple switches rapidly
+        session.request_device_switch(mic_device=mock_audio_devices["mic2"])
+        session.request_device_switch(loopback_device=mock_audio_devices["loopback2"])
+
+        # Only the last request should be pending
+        mic, loopback = session.get_pending_switch()
+
+        # The loopback should be set (last request)
+        assert loopback is mock_audio_devices["loopback2"]

--- a/tests/test_input_handler.py
+++ b/tests/test_input_handler.py
@@ -1,0 +1,236 @@
+"""Tests for the keyboard input handler module."""
+
+import sys
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omr.core.input_handler import (
+    InputCommand,
+    InputEvent,
+    KeyInputHandler,
+    SelectionMode,
+    is_input_available,
+)
+
+
+class TestInputCommand:
+    """Tests for InputCommand enum."""
+
+    def test_all_commands_defined(self):
+        """Verify all expected commands are defined."""
+        assert InputCommand.STOP is not None
+        assert InputCommand.SWITCH_MIC is not None
+        assert InputCommand.SWITCH_LOOPBACK is not None
+        assert InputCommand.SELECT_DEVICE is not None
+        assert InputCommand.CANCEL is not None
+        assert InputCommand.REFRESH_DEVICES is not None
+
+
+class TestSelectionMode:
+    """Tests for SelectionMode enum."""
+
+    def test_all_modes_defined(self):
+        """Verify all expected modes are defined."""
+        assert SelectionMode.NONE is not None
+        assert SelectionMode.MIC is not None
+        assert SelectionMode.LOOPBACK is not None
+
+
+class TestInputEvent:
+    """Tests for InputEvent dataclass."""
+
+    def test_create_event_without_value(self):
+        """Test creating an event without a value."""
+        event = InputEvent(InputCommand.STOP)
+        assert event.command == InputCommand.STOP
+        assert event.value is None
+
+    def test_create_event_with_value(self):
+        """Test creating an event with a value."""
+        event = InputEvent(InputCommand.SELECT_DEVICE, value=5)
+        assert event.command == InputCommand.SELECT_DEVICE
+        assert event.value == 5
+
+    def test_repr_without_value(self):
+        """Test string representation without value."""
+        event = InputEvent(InputCommand.STOP)
+        assert "STOP" in repr(event)
+        assert "value" not in repr(event)
+
+    def test_repr_with_value(self):
+        """Test string representation with value."""
+        event = InputEvent(InputCommand.SELECT_DEVICE, value=3)
+        assert "SELECT_DEVICE" in repr(event)
+        assert "value=3" in repr(event)
+
+
+class TestKeyInputHandler:
+    """Tests for KeyInputHandler class."""
+
+    def test_initial_state(self):
+        """Test initial state of handler."""
+        handler = KeyInputHandler()
+        assert handler.selection_mode == SelectionMode.NONE
+
+    def test_enter_selection_mode(self):
+        """Test entering selection mode."""
+        handler = KeyInputHandler()
+        handler.enter_selection_mode(SelectionMode.MIC)
+        assert handler.selection_mode == SelectionMode.MIC
+
+        handler.enter_selection_mode(SelectionMode.LOOPBACK)
+        assert handler.selection_mode == SelectionMode.LOOPBACK
+
+    def test_exit_selection_mode(self):
+        """Test exiting selection mode."""
+        handler = KeyInputHandler()
+        handler.enter_selection_mode(SelectionMode.MIC)
+        handler.exit_selection_mode()
+        assert handler.selection_mode == SelectionMode.NONE
+
+    def test_start_stop(self):
+        """Test starting and stopping the handler."""
+        handler = KeyInputHandler()
+        handler.start()
+        assert handler._thread is not None
+        assert handler._thread.is_alive()
+
+        handler.stop()
+        # Thread should stop within timeout
+        time.sleep(0.2)
+        assert not handler._thread.is_alive() if handler._thread else True
+
+    def test_context_manager(self):
+        """Test using handler as context manager."""
+        with KeyInputHandler() as handler:
+            assert handler._thread is not None
+            assert handler._thread.is_alive()
+        # After exit, thread should be stopped
+        time.sleep(0.2)
+
+    def test_get_event_timeout(self):
+        """Test get_event returns None on timeout."""
+        handler = KeyInputHandler()
+        event = handler.get_event(timeout=0.01)
+        assert event is None
+
+    def test_process_key_q_in_normal_mode(self):
+        """Test 'q' key generates STOP command in normal mode."""
+        handler = KeyInputHandler()
+        handler._process_key(b"q")
+        event = handler.get_event(timeout=0.1)
+        assert event is not None
+        assert event.command == InputCommand.STOP
+
+    def test_process_key_m_in_normal_mode(self):
+        """Test 'm' key generates SWITCH_MIC command in normal mode."""
+        handler = KeyInputHandler()
+        handler._process_key(b"m")
+        event = handler.get_event(timeout=0.1)
+        assert event is not None
+        assert event.command == InputCommand.SWITCH_MIC
+
+    def test_process_key_l_in_normal_mode(self):
+        """Test 'l' key generates SWITCH_LOOPBACK command in normal mode."""
+        handler = KeyInputHandler()
+        handler._process_key(b"l")
+        event = handler.get_event(timeout=0.1)
+        assert event is not None
+        assert event.command == InputCommand.SWITCH_LOOPBACK
+
+    def test_process_key_r_in_normal_mode(self):
+        """Test 'r' key generates REFRESH_DEVICES command in normal mode."""
+        handler = KeyInputHandler()
+        handler._process_key(b"r")
+        event = handler.get_event(timeout=0.1)
+        assert event is not None
+        assert event.command == InputCommand.REFRESH_DEVICES
+
+    def test_process_number_in_selection_mode(self):
+        """Test number keys generate SELECT_DEVICE in selection mode."""
+        handler = KeyInputHandler()
+        handler.enter_selection_mode(SelectionMode.MIC)
+
+        handler._process_key(b"5")
+        event = handler.get_event(timeout=0.1)
+        assert event is not None
+        assert event.command == InputCommand.SELECT_DEVICE
+        assert event.value == 5
+
+    def test_process_escape_in_selection_mode(self):
+        """Test Escape key generates CANCEL in selection mode."""
+        handler = KeyInputHandler()
+        handler.enter_selection_mode(SelectionMode.MIC)
+
+        handler._process_key(b"\x1b")  # Escape key
+        event = handler.get_event(timeout=0.1)
+        assert event is not None
+        assert event.command == InputCommand.CANCEL
+
+    def test_process_q_in_selection_mode(self):
+        """Test 'q' key still generates STOP in selection mode."""
+        handler = KeyInputHandler()
+        handler.enter_selection_mode(SelectionMode.MIC)
+
+        handler._process_key(b"q")
+        event = handler.get_event(timeout=0.1)
+        assert event is not None
+        assert event.command == InputCommand.STOP
+
+    def test_unknown_key_ignored_in_normal_mode(self):
+        """Test unknown keys are ignored in normal mode."""
+        handler = KeyInputHandler()
+        handler._process_key(b"x")
+        event = handler.get_event(timeout=0.01)
+        assert event is None
+
+    def test_case_insensitive_keys(self):
+        """Test keys are case insensitive."""
+        handler = KeyInputHandler()
+
+        handler._process_key(b"Q")
+        event = handler.get_event(timeout=0.1)
+        assert event is not None
+        assert event.command == InputCommand.STOP
+
+        handler._process_key(b"M")
+        event = handler.get_event(timeout=0.1)
+        assert event is not None
+        assert event.command == InputCommand.SWITCH_MIC
+
+    def test_double_start(self):
+        """Test calling start twice doesn't create multiple threads."""
+        handler = KeyInputHandler()
+        handler.start()
+        thread1 = handler._thread
+
+        handler.start()  # Second call
+        thread2 = handler._thread
+
+        assert thread1 is thread2
+        handler.stop()
+
+
+class TestIsInputAvailable:
+    """Tests for is_input_available function."""
+
+    def test_returns_boolean(self):
+        """Test function returns a boolean."""
+        result = is_input_available()
+        assert isinstance(result, bool)
+
+    @patch.object(sys, "platform", "win32")
+    def test_windows_platform(self):
+        """Test on Windows platform."""
+        # Just verify it doesn't crash
+        result = is_input_available()
+        assert isinstance(result, bool)
+
+    @patch.object(sys, "platform", "linux")
+    def test_linux_platform(self):
+        """Test on Linux platform."""
+        result = is_input_available()
+        assert result is True


### PR DESCRIPTION
## Summary
- Add dynamic mic/loopback device switching via keyboard during active recording
- Non-blocking keyboard input using msvcrt (Windows standard library)
- Add keyboard shortcuts display to Rich Live UI

## Key Mappings
| Key | Function |
|-----|----------|
| `m` | Enter mic selection mode → select device with number keys |
| `l` | Enter loopback selection mode → select device with number keys |
| `0-9` | Select device by number (in selection mode only) |
| `Esc` | Cancel selection |
| `q` | Stop recording (same as Ctrl+C) |
| `r` | Refresh device list |

## Changed Files
- `src/omr/core/input_handler.py` - **New** keyboard input handler module
- `src/omr/core/audio_capture.py` - Add device switching API to RecordingSession
- `src/omr/backends/wasapi.py` - Add device switching logic to recording loops
- `src/omr/cli/commands/record.py` - Integrate UI and keyboard handling
- `tests/test_input_handler.py` - **New** input handler tests
- `tests/test_device_switching.py` - **New** device switching tests

## Test Plan
- [x] Unit tests: All 98 tests passing
- [x] Manual testing on Windows
- [x] Keyboard input verification
- [x] Device switching verification

Closes #10